### PR TITLE
macOS requires env

### DIFF
--- a/iso-deployment.md
+++ b/iso-deployment.md
@@ -9,7 +9,13 @@ Run the command `make deploy` to deploy `private/master` to Hockey.
 ### App Store Deployment
 
 1. Bump the version number in Xcode and commit (build number is set automatically).
-2. Run the command `env RELEASE=itunes make deploy` to deploy `private/master` to iTunes connect.
+2. Deploy `private/master` to iTunes connect by running the following command:
+
+bash/zsh:  
+`RELEASE=itunes make deploy`
+
+fish:  
+`env RELEASE=itunes make deploy`
 
 ### iTunes connect
 

--- a/iso-deployment.md
+++ b/iso-deployment.md
@@ -9,7 +9,7 @@ Run the command `make deploy` to deploy `private/master` to Hockey.
 ### App Store Deployment
 
 1. Bump the version number in Xcode and commit (build number is set automatically).
-2. Run the command `RELEASE=itunes make deploy` to deploy `private/master` to iTunes connect.
+2. Run the command `env RELEASE=itunes make deploy` to deploy `private/master` to iTunes connect.
 
 ### iTunes connect
 


### PR DESCRIPTION
I need `env` when attempting to run this just now:

```
~/D/kickstarter (master|✔) $ RELEASE=itunes make deploy
Unsupported use of '='. To run 'make' with a modified environment, please use 'env RELEASE=itunes make…'
~/D/kickstarter (master|✔) $ env RELEASE=itunes make deploy
Deploying private/master to itunes...
```